### PR TITLE
Refactor the way generators are used by the main program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,15 +285,3 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
-© 2021 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenAPI to Terraform
 # Getting Started #
 1. Install as a [global tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-global-tool)
     ```
-    dotnet tool install -g --version 0.0.1 openapi-to-terraform
+    dotnet tool install -g --version 0.0.9 openapi-to-terraform
     ```
 2. Verify that the tool was installed correctly
 
@@ -84,4 +84,3 @@ APIM Policies (Not Implemented):
 Tool Versions:
 * Currently, the tool will only generate terraform files conformant to hashicorp/azurerm version "~> 2.45.1"
 * The sample files (which are used for unit tests and validation) use terraform "> 0.13.0"
-* Could add further support for switching to other versions but for now those will be hardcoded

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ OpenAPI to Terraform
     openapi-to-terraform -f [openApiPath] -o [outputDir] -t [terraformVarsJson]
     ```
     Where 
-    1. [openApiPath] = path to OpenAPI file
-    2. [outputDir] = output directory for API and Operation terraform files
-    3. [terraformVarsJson] = path to terraform variables mapping file
+    * [openApiPath] = path to OpenAPI file
+    * [outputDir] = output directory for API and Operation terraform files
+    * [terraformVarsJson] = path to terraform variables mapping file
 
 There are some additional considerations when generating a file:
 
 Terraform Variables File:
 * You are required to provide either a terraform variables mapping file (to the -t option) *or* an API template/Operation template file
 * The terraform variables mapping file must contain the following keys:
-    1. "api_management_service_name" - the string or terraform variable reference to use to populate the api_management_name part of the blocks
-    2. "api_management_resource_group_name" - the string or terraform variable reference to use to populate the tresource_group_name part of the blocks
-    3. "api_path" - the string or terraform variable reference to use to populate the azurerm_api_management_api.api_path field
-    4. "api_backend_url" - the string or terraform variable reference to use to populate the azurerm_api_management_api.service_url
-    5. "api_management_product_id" - the string or terraform variable reference to use to populate the azurerm_api_management_product_api.product_id
-    6. "api_management_version_set_id" - the string or terraform variable reference to use to populate the azurerm_api_management_api.version_set_id field
+    * "api_management_service_name" - the string or terraform variable reference to use to populate the api_management_name part of the blocks
+    * "api_management_resource_group_name" - the string or terraform variable reference to use to populate the tresource_group_name part of the blocks
+    * "api_path" - the string or terraform variable reference to use to populate the azurerm_api_management_api.api_path field
+    * "api_backend_url" - the string or terraform variable reference to use to populate the azurerm_api_management_api.service_url
+    * "api_management_product_id" - the string or terraform variable reference to use to populate the azurerm_api_management_product_api.product_id
+    * "api_management_version_set_id" - the string or terraform variable reference to use to populate the azurerm_api_management_api.version_set_id field
 * NOTE: Because these are meant to represent fields in terraform, changing them will change the plan, which may have unintended consequences in your environment
 
 Revision Mapping File:

--- a/openapi-to-terraform.Generator/Attributes/ProviderVersionAttribute.cs
+++ b/openapi-to-terraform.Generator/Attributes/ProviderVersionAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace openapi_to_terraform.Generator.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class ProviderVersionAttribute : Attribute
+    {
+        public string ProviderVersion
+        {
+            get
+            {
+                return _providerVersion;
+            }
+        }
+
+        private string _providerVersion { get; set; }
+        
+        public ProviderVersionAttribute(string providerVersion)
+        {
+            _providerVersion = providerVersion;
+        }
+    }
+}

--- a/openapi-to-terraform.Generator/ITerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/ITerraformGenerator.cs
@@ -1,0 +1,8 @@
+using Microsoft.OpenApi.Models;
+
+namespace openapi_to_terraform.Generator {
+    interface ITerraformGenerator {
+        void GenerateWithTerraformVars(OpenApiDocument document);
+        void GenerateWithTemplateFiles(OpenApiDocument document);
+    }
+}

--- a/openapi-to-terraform.Generator/ITerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/ITerraformGenerator.cs
@@ -1,7 +1,9 @@
 using Microsoft.OpenApi.Models;
 
-namespace openapi_to_terraform.Generator {
-    interface ITerraformGenerator {
+namespace openapi_to_terraform.Generator
+{
+    public interface ITerraformGenerator
+    {
         void GenerateWithTerraformVars(OpenApiDocument document);
         void GenerateWithTemplateFiles(OpenApiDocument document);
     }

--- a/openapi-to-terraform.Generator/TerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/TerraformGenerator.cs
@@ -1,0 +1,26 @@
+namespace openapi_to_terraform.Generator
+{
+    public abstract class TerraformGenerator
+    {
+        protected string OutputDir { get; set; }
+        protected string TerraformVarSubFile { get; set; }
+        protected string ApiTemplateFile { get; set; }
+        protected string OperationTemplateFile { get; set; }
+        protected string RevisionMappingFile { get; set; }
+
+        public TerraformGenerator(string outputDir, string terraformVariablesFile, string revisionMap)
+        {
+            OutputDir = outputDir.EndsWith('/') ? outputDir : outputDir + '/';
+            TerraformVarSubFile = terraformVariablesFile;
+            RevisionMappingFile = revisionMap;
+        }
+
+        public TerraformGenerator(string outputDir, string apiTemplatePath, string operationTemplatePath, string revisionMap)
+        {
+            OutputDir = outputDir.EndsWith('/') ? outputDir : outputDir + '/';
+            ApiTemplateFile = apiTemplatePath;
+            OperationTemplateFile = operationTemplatePath;
+            RevisionMappingFile = revisionMap;
+        }
+    }
+}

--- a/openapi-to-terraform.Generator/TerraformGeneratorRegistry.cs
+++ b/openapi-to-terraform.Generator/TerraformGeneratorRegistry.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Reflection;
+using Autofac;
+using openapi_to_terraform.Generator.Attributes;
+
+namespace openapi_to_terraform.Generator
+{
+    public static class TerraformGeneratorRegistry
+    {
+        // To register a new provider implementation, do the following:
+        // 1. Create a folder structure with the provider name, then the version you want to add support for
+        // 2. There must be a class that inherits from TerraformGenerator and implements ITerraformGenerator in that folder structure
+        // 3. That class must also have a ProviderVersion attribute with the {provider}_{providerVersion} string to register here
+        public static ContainerBuilder RegisterGeneratorTypes(ContainerBuilder builder)
+        {
+            builder.RegisterAssemblyTypes(typeof(TerraformGenerator).Assembly)
+                .Where(t => t.IsSubclassOf(typeof(TerraformGenerator)) && t.GetInterfaces().Contains(typeof(ITerraformGenerator)))
+                .Named<ITerraformGenerator>(t => t.GetCustomAttribute<ProviderVersionAttribute>()?.ProviderVersion);
+            return builder;
+        }
+    }
+}

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/Azurerm_v2_45_1_TerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/Azurerm_v2_45_1_TerraformGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 using openapi_to_terraform.Generator.Attributes;
@@ -13,14 +14,22 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1
     [ProviderVersion("azurerm_v2.45.1")]
     public class Azurerm_v2_45_1_TerraformGenerator : TerraformGenerator, ITerraformGenerator
     {
-        public Azurerm_v2_45_1_TerraformGenerator(string outputDir, string terraformVariablesFile, string revisionMap)
-            : base(outputDir, terraformVariablesFile, revisionMap) { }
+        private readonly ILogger<Azurerm_v2_45_1_TerraformGenerator> logger;
+        public Azurerm_v2_45_1_TerraformGenerator(ILogger<Azurerm_v2_45_1_TerraformGenerator> logger, string outputDir, string terraformVariablesFile, string revisionMap)
+            : base(outputDir, terraformVariablesFile, revisionMap)
+        {
+            this.logger = logger;
+        }
 
-        public Azurerm_v2_45_1_TerraformGenerator(string outputDir, string apiTemplatePath, string operationTemplatePath, string revisionMap)
-            : base(outputDir, apiTemplatePath, operationTemplatePath, revisionMap) { }
+        public Azurerm_v2_45_1_TerraformGenerator(ILogger<Azurerm_v2_45_1_TerraformGenerator> logger, string outputDir, string apiTemplatePath, string operationTemplatePath, string revisionMap)
+            : base(outputDir, apiTemplatePath, operationTemplatePath, revisionMap)
+        {
+            this.logger = logger;
+        }
 
         public void GenerateWithTerraformVars(OpenApiDocument document)
         {
+            logger.LogDebug("In GenerateWithTerraformVars");
             var version = document.Info.Version;
             var revisions = new List<string>();
 

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/Azurerm_v2_45_1_TerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/Azurerm_v2_45_1_TerraformGenerator.cs
@@ -4,32 +4,20 @@ using System.IO;
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
+using openapi_to_terraform.Generator.Attributes;
 using openapi_to_terraform.Generator.azurerm.v2_45_1.Generators;
 using openapi_to_terraform.Generator.azurerm.v2_45_1.VariablesAppliers;
 
 namespace openapi_to_terraform.Generator.azurerm.v2_45_1
 {
-    public class TerraformGenerator : ITerraformGenerator
+    [ProviderVersion("azurerm_v2.45.1")]
+    public class Azurerm_v2_45_1_TerraformGenerator : TerraformGenerator, ITerraformGenerator
     {
-        private string OutputDir { get; set; }
-        private string TerraformVarSubFile { get; set; }
-        private string ApiTemplateFile { get; set; }
-        private string OperationTemplateFile { get; set; }
-        private string RevisionMappingFile { get; set; }
+        public Azurerm_v2_45_1_TerraformGenerator(string outputDir, string terraformVariablesFile, string revisionMap)
+            : base(outputDir, terraformVariablesFile, revisionMap) { }
 
-        public TerraformGenerator(string outputDir, string terraformVariablesFile, string revisionMap)
-        {
-            OutputDir = outputDir.EndsWith('/') ? outputDir : outputDir + '/';
-            TerraformVarSubFile = terraformVariablesFile;
-            RevisionMappingFile = revisionMap;
-        }
-        public TerraformGenerator(string outputDir, string apiTemplatePath, string operationTemplatePath, string revisionMap)
-        {
-            OutputDir = outputDir.EndsWith('/') ? outputDir : outputDir + '/';
-            ApiTemplateFile = apiTemplatePath;
-            OperationTemplateFile = operationTemplatePath;
-            RevisionMappingFile = revisionMap;
-        }
+        public Azurerm_v2_45_1_TerraformGenerator(string outputDir, string apiTemplatePath, string operationTemplatePath, string revisionMap)
+            : base(outputDir, apiTemplatePath, operationTemplatePath, revisionMap) { }
 
         public void GenerateWithTerraformVars(OpenApiDocument document)
         {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApiProductApi.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApiProductApi.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Microsoft.OpenApi.Models;
 
-namespace openapi_to_terraform.Generator.GeneratorModels
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
 {
     public class TerraformApimProductApi
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimApi.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimApi.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Microsoft.OpenApi.Models;
 
-namespace openapi_to_terraform.Generator.GeneratorModels
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
 {
     public class TerraformApimApi
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.OpenApi.Models;
 
-namespace openapi_to_terraform.Generator.GeneratorModels
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
 {
     public class TerraformApimOperation
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/Generators/ApiGenerator.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/Generators/ApiGenerator.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.OpenApi.Models;
-using openapi_to_terraform.Generator.GeneratorModels;
+using openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels;
 
-namespace openapi_to_terraform.Generator.Generators
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.Generators
 {
     public class ApiGenerator
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/Generators/OperationGenerator.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/Generators/OperationGenerator.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System.Text;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
-using openapi_to_terraform.Generator.GeneratorModels;
+using openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels;
 
-namespace openapi_to_terraform.Generator.Generators
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.Generators
 {
     public class OperationGenerator
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/TemplateAppliers/ApiTemplateApplier.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/TemplateAppliers/ApiTemplateApplier.cs
@@ -1,4 +1,4 @@
-namespace openapi_to_terraform.Generator.TemplateAppliers
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.TemplateAppliers
 {
     public class ApiTemplateApplier
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/TemplateAppliers/OperationTemplateApplier.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/TemplateAppliers/OperationTemplateApplier.cs
@@ -1,8 +1,8 @@
 using System.Text;
 using Microsoft.OpenApi.Models;
-using openapi_to_terraform.Generator.GeneratorModels;
+using openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels;
 
-namespace openapi_to_terraform.Generator.TemplateAppliers
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.TemplateAppliers
 {
     public class OperationTemplateApplier
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/TerraformGenerator.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/TerraformGenerator.cs
@@ -4,12 +4,12 @@ using System.IO;
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
-using openapi_to_terraform.Generator.Generators;
-using openapi_to_terraform.Generator.VariablesAppliers;
+using openapi_to_terraform.Generator.azurerm.v2_45_1.Generators;
+using openapi_to_terraform.Generator.azurerm.v2_45_1.VariablesAppliers;
 
-namespace openapi_to_terraform.Generator
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1
 {
-    public class TerraformGenerator
+    public class TerraformGenerator : ITerraformGenerator
     {
         private string OutputDir { get; set; }
         private string TerraformVarSubFile { get; set; }

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/VariablesAppliers/ApiVariablesApplier.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/VariablesAppliers/ApiVariablesApplier.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Newtonsoft.Json.Linq;
 
-namespace openapi_to_terraform.Generator.VariablesAppliers
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.VariablesAppliers
 {
     public class ApiVariablesApplier
     {

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/VariablesAppliers/OperationVariablesApplier.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/VariablesAppliers/OperationVariablesApplier.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Newtonsoft.Json.Linq;
 
-namespace openapi_to_terraform.Generator.VariablesAppliers
+namespace openapi_to_terraform.Generator.azurerm.v2_45_1.VariablesAppliers
 {
     public class OperationVariablesApplier
     {

--- a/openapi-to-terraform.Generator/openapi-to-terraform.Generator.csproj
+++ b/openapi-to-terraform.Generator/openapi-to-terraform.Generator.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="6.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/openapi-to-terraform.Generator/openapi-to-terraform.Generator.csproj
+++ b/openapi-to-terraform.Generator/openapi-to-terraform.Generator.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/openapi-to-terraform.Main/Options.cs
+++ b/openapi-to-terraform.Main/Options.cs
@@ -13,16 +13,22 @@ namespace openapi_to_terraform.Main
         [Option('r', "revision-map-file", Required = false, HelpText = "(Not Implemented) Absolute or relative path to revision mapping json file")]
         public string RevisionFile { get; set; }
 
-        [Option('p', "policies", Required = false, HelpText = "(Not Implemented) Absolute or relative path to directory containing APIM policies. Requires -r/--revision-map-file to be provided if revision dependent policies are desired")]
-        public string PoliciesDirectoryPath { get; set; }
-
         [Option('t', "terraform-vars-file", SetName = "terraform-vars", HelpText = "Absolute or relative path to file mapping terraform variables to output values")]
         public string TerraformVariablesFile { get; set; }
-        
+
+        [Option('p', "provider", Default = "azurerm", Required = false, HelpText = "One of { azurerm }. Defaults to azurerm")]
+        public string Provider { get; set; }
+
+        [Option("provider-version", Default = "v2.45.1", Required = false, HelpText = "Version of the provider to use. Defaults to v2.45.1")]
+        public string ProviderVersion { get; set; }
+
         [Option("api-template-file", SetName = "template-provided", HelpText = "(Not Implemented) Absolute or relative path to desired template of APIs terraform file")]
         public string ApiTemplateFile { get; set; }
 
         [Option("operation-template-file", SetName = "template-provided", HelpText = "(Not Implemented) Absolute or relative path to desired template of Operations terraform file")]
         public string OperationTemplateFile { get; set; }
+
+        [Option("policies", Required = false, HelpText = "(Not Implemented) Absolute or relative path to directory containing APIM policies. Requires -r/--revision-map-file to be provided if revision dependent policies are desired")]
+        public string PoliciesDirectoryPath { get; set; }
     }
 }

--- a/openapi-to-terraform.Main/Program.cs
+++ b/openapi-to-terraform.Main/Program.cs
@@ -3,30 +3,93 @@ using CommandLine;
 using openapi_to_terraform.Core;
 using openapi_to_terraform.Main;
 using openapi_to_terraform.Generator;
+using Microsoft.Extensions.DependencyInjection;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using Autofac.Core;
+using Autofac.Core.Registration;
 
 namespace openapi_to_terraform
 {
     public class Program
     {
+        private static IServiceProvider _serviceProvider;
+
         public static void Main(string[] args)
         {
             Parser.Default.ParseArguments<Options>(args)
                    .WithParsed<Options>(o =>
                    {
+                       RegisterServices();
+
                        Console.WriteLine($"Parsing {o.InputFile}, outputting to {o.OutputDirectory}");
+
+                       var serviceName = o.Provider + "_" + o.ProviderVersion;
+
                        OpenApiParser p = new OpenApiParser(o.InputFile);
                        p.Parse();
+
                        if (o.TerraformVariablesFile != null)
                        {
-                           var generator = new TerraformGenerator(o.OutputDirectory, o.TerraformVariablesFile, o.RevisionFile);
-                           generator.GenerateWithTerraformVars(p.Document);
+                           var parameters = new List<Parameter>();
+                           parameters.Add(new NamedParameter("outputDir", o.OutputDirectory));
+                           parameters.Add(new NamedParameter("terraformVariablesFile", o.TerraformVariablesFile));
+                           parameters.Add(new NamedParameter("revisionMap", o.RevisionFile));
+                           try
+                           {
+                               var generator = _serviceProvider.GetAutofacRoot().ResolveNamed<ITerraformGenerator>(serviceName, parameters);
+                               generator.GenerateWithTerraformVars(p.Document);
+                           }
+                           catch (ComponentNotRegisteredException e)
+                           {
+                               Console.WriteLine($"Service with provider version {serviceName} not found");
+                           }
                        }
                        else if (o.ApiTemplateFile != null && o.OperationTemplateFile != null)
                        {
-                           var generator = new TerraformGenerator(o.OutputDirectory, o.ApiTemplateFile, o.OperationTemplateFile, o.RevisionFile);
-                           generator.GenerateWithTemplateFiles(p.Document);
+                           var parameters = new List<Parameter>();
+                           parameters.Add(new NamedParameter("outputDir", o.OutputDirectory));
+                           parameters.Add(new NamedParameter("apiTemplatePath", o.ApiTemplateFile));
+                           parameters.Add(new NamedParameter("operationTemplatePath", o.OperationTemplateFile));
+                           parameters.Add(new NamedParameter("revisionMap", o.RevisionFile));
+                           try
+                           {
+                               var generator = _serviceProvider.GetAutofacRoot().ResolveNamed<ITerraformGenerator>(serviceName, parameters);
+                               generator.GenerateWithTemplateFiles(p.Document);
+                           }
+                           catch (ComponentNotRegisteredException e)
+                           {
+                               Console.WriteLine($"Service with provider version {serviceName} not found");
+                           }
                        }
+                       DisposeServices();
                    });
+        }
+
+        private static void RegisterServices()
+        {
+            var services = new ServiceCollection().AddLogging();
+            var builder = new ContainerBuilder();
+
+            builder = TerraformGeneratorRegistry.RegisterGeneratorTypes(builder);
+
+            builder.Populate(services);
+
+            var appContainer = builder.Build();
+            _serviceProvider = new AutofacServiceProvider(appContainer);
+        }
+
+        private static void DisposeServices()
+        {
+            if (_serviceProvider == null)
+            {
+                return;
+            }
+            if (_serviceProvider is IDisposable)
+            {
+                ((IDisposable)_serviceProvider).Dispose();
+            }
         }
     }
 }

--- a/openapi-to-terraform.Main/Program.cs
+++ b/openapi-to-terraform.Main/Program.cs
@@ -9,6 +9,7 @@ using Autofac.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using Autofac.Core;
 using Autofac.Core.Registration;
+using Microsoft.Extensions.Logging;
 
 namespace openapi_to_terraform
 {
@@ -22,7 +23,7 @@ namespace openapi_to_terraform
                    .WithParsed<Options>(o =>
                    {
                        RegisterServices();
-
+                       var logger = _serviceProvider.GetAutofacRoot().Resolve<ILogger<Program>>();
                        Console.WriteLine($"Parsing {o.InputFile}, outputting to {o.OutputDirectory}");
 
                        var serviceName = o.Provider + "_" + o.ProviderVersion;
@@ -43,6 +44,7 @@ namespace openapi_to_terraform
                            }
                            catch (ComponentNotRegisteredException e)
                            {
+                               logger.LogError(e.Message, e);
                                Console.WriteLine($"Service with provider version {serviceName} not found");
                            }
                        }
@@ -60,6 +62,7 @@ namespace openapi_to_terraform
                            }
                            catch (ComponentNotRegisteredException e)
                            {
+                               logger.LogError(e.Message, e);
                                Console.WriteLine($"Service with provider version {serviceName} not found");
                            }
                        }

--- a/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
+++ b/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
@@ -13,7 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="6.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
   </ItemGroup>
 

--- a/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
+++ b/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
@@ -9,7 +9,7 @@
     <PackageId>openapi-to-terraform</PackageId>
     <ToolCommandName>openapi-to-terraform</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageVersion>0.0.8</PackageVersion>
+    <PackageVersion>0.0.9</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openapi-to-terraform.Tests/GeneratorTests.cs
+++ b/openapi-to-terraform.Tests/GeneratorTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
 using Newtonsoft.Json;
 using Xunit;
 

--- a/openapi-to-terraform.Tests/GeneratorTests.cs
+++ b/openapi-to-terraform.Tests/GeneratorTests.cs
@@ -11,6 +11,24 @@ namespace openapi_to_terraform.Tests
     public class GeneratorTests
     {
         [Fact]
+        public void tool_should_fail_with_bad_provider_settings()
+        {
+            var outputDir = Regex.Replace($"output_without_api_revisions_{DateTime.Now.ToString()}", @"[\s:\/]", "_");
+            var sampleOpenApi = "samples/sampleOpenApi.json";
+            var terraformSubVarsFile = "samples/sampleTerraformVars.json";
+
+            Program.Main(new[] { "-f", sampleOpenApi, "-o", outputDir, "-t", terraformSubVarsFile, "-p", "aws" });
+
+            Directory.Exists(outputDir).Should().BeFalse();
+            Program.Main(new[] { "-f", sampleOpenApi, "-o", outputDir, "-t", terraformSubVarsFile, "--provider-version", "v0.1" });
+
+            Directory.Exists(outputDir).Should().BeFalse();
+            Program.Main(new[] { "-f", sampleOpenApi, "-o", outputDir, "-t", terraformSubVarsFile, "-p", "aws", "--provider-version", "v0.1" });
+
+            Directory.Exists(outputDir).Should().BeFalse();
+        }
+
+        [Fact]
         public void tool_should_generate_one_api_block_without_revisions_mapping()
         {
             var outputDir = Regex.Replace($"output_without_api_revisions_{DateTime.Now.ToString()}", @"[\s:\/]", "_");
@@ -19,13 +37,13 @@ namespace openapi_to_terraform.Tests
 
             Program.Main(new[] { "-f", sampleOpenApi, "-o", outputDir, "-t", terraformSubVarsFile });
 
-            File.Copy("samples/sampleMainModule.tf", Path.Combine(outputDir, "sampleMainModule.tf"));
-            File.Copy("samples/sampleMainApim.tf", Path.Combine(outputDir, "sampleMainApim.tf"));
-            File.Copy("samples/sampleApimVariables.tf", Path.Combine(outputDir, "sampleApimVariables.tf"));
-
             Directory.Exists(outputDir).Should().BeTrue();
             File.Exists(Path.Combine(outputDir, "api.1.tf")).Should().BeTrue();
             File.Exists(Path.Combine(outputDir, "operations.1.tf")).Should().BeTrue();
+
+            File.Copy("samples/sampleMainModule.tf", Path.Combine(outputDir, "sampleMainModule.tf"));
+            File.Copy("samples/sampleMainApim.tf", Path.Combine(outputDir, "sampleMainApim.tf"));
+            File.Copy("samples/sampleApimVariables.tf", Path.Combine(outputDir, "sampleApimVariables.tf"));
 
             var apiText = File.ReadAllText(Path.Combine(outputDir, "api.1.tf"));
             int apiBlockCount = Regex.Matches(apiText, "resource \"azurerm_api_management_api\"").Count;
@@ -62,13 +80,13 @@ namespace openapi_to_terraform.Tests
 
             Program.Main(new[] { "-f", sampleOpenApi, "-o", outputDir, "-t", terraformSubVarsFile, "-r", revisionsMappingFile });
 
-            File.Copy("samples/sampleMainModule.tf", Path.Combine(outputDir, "sampleMainModule.tf"));
-            File.Copy("samples/sampleMainApim.tf", Path.Combine(outputDir, "sampleMainApim.tf"));
-            File.Copy("samples/sampleApimVariables.tf", Path.Combine(outputDir,"sampleApimVariables.tf"));
-
             Directory.Exists(outputDir).Should().BeTrue();
             File.Exists(Path.Combine(outputDir, "api.1.tf")).Should().BeTrue();
             File.Exists(Path.Combine(outputDir, "operations.1.tf")).Should().BeTrue();
+
+            File.Copy("samples/sampleMainModule.tf", Path.Combine(outputDir, "sampleMainModule.tf"));
+            File.Copy("samples/sampleMainApim.tf", Path.Combine(outputDir, "sampleMainApim.tf"));
+            File.Copy("samples/sampleApimVariables.tf", Path.Combine(outputDir, "sampleApimVariables.tf"));
 
             var apiText = File.ReadAllText(Path.Combine(outputDir, "api.1.tf"));
             int apiBlockCount = Regex.Matches(apiText, "resource \"azurerm_api_management_api\"").Count;


### PR DESCRIPTION
To allow for extensibility, I changed up the structure of the Generators project a bit to allow for additional provider/version combos to be added in the future, and added command line options to support them. Right now there's only one generator and the defaults select it, any other provided command line input for those args will cause a failure.