### PR TITLE
fix description null issue for operations

### DIFF
--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
@@ -27,7 +27,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                         sb.AppendLine($"\tapi_name\t=\tazurerm_api_management_api.{apiResourceName}.name");
                         sb.AppendLine($"\tapi_management_name\t=\t{{api_management_service_name}}");
                         sb.AppendLine($"\tresource_group_name\t=\t{{api_management_resource_group_name}}");
-                        sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary}\"");
+                        sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary?.Replace("\r\n", " ")}\"");
                         sb.AppendLine($"\tmethod\t=\t\"{operation.Key.ToString().ToUpper()}\"");
                         sb.AppendLine($"\turl_template\t=\t\"{removeBackendServiceSegments(backendUrl, path.Key)}\"");
                         sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description?.Replace("\r\n", " ")}\"");
@@ -40,7 +40,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                                     sb.AppendLine($"\t\tname\t=\t\"{parameter.Name}\"");
                                     sb.AppendLine($"\t\trequired\t=\t{parameter.Required.ToString().ToLower()}");
                                     sb.AppendLine($"\t\ttype\t=\t\"{parameter.Schema.Format}\"");
-                                    sb.AppendLine($"\t\tdescription\t=\t\"{parameter.Description}\"");
+                                    sb.AppendLine($"\t\tdescription\t=\t\"{parameter.Description?.Replace("\r\n", " ")}\"");
                                     sb.AppendLine("\t}");
                                     break;
                             }
@@ -85,7 +85,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                     sb.AppendLine($"\tapi_name\t=\tazurerm_api_management_api.{apiResourceName}.name");
                     sb.AppendLine($"\tapi_management_name\t=\t{{api_management_service_name}}");
                     sb.AppendLine($"\tresource_group_name\t=\t{{api_management_resource_group_name}}");
-                    sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary}\"");
+                    sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary?.Replace("\r\n", " ")}\"");
                     sb.AppendLine($"\tmethod\t=\t\"{operation.Key.ToString().ToUpper()}\"");
                     sb.AppendLine($"\turl_template\t=\t\"{removeBackendServiceSegments(backendUrl, path.Key)}\"");
                     sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description?.Replace("\r\n", " ")}\"");
@@ -98,7 +98,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                                 sb.AppendLine($"\t\tname\t=\t\"{parameter.Name}\"");
                                 sb.AppendLine($"\t\trequired\t=\t{parameter.Required.ToString().ToLower()}");
                                 sb.AppendLine($"\t\ttype\t=\t\"{parameter.Schema.Format}\"");
-                                sb.AppendLine($"\t\tdescription\t=\t\"{parameter.Description}\"");
+                                sb.AppendLine($"\t\tdescription\t=\t\"{parameter.Description?.Replace("\r\n", " ")}\"");
                                 sb.AppendLine("\t}");
                                 break;
                         }
@@ -107,7 +107,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                     {
                         sb.AppendLine("\tresponse {");
                         sb.AppendLine($"\t\tstatus_code\t=\t{response.Key}");
-                        sb.AppendLine($"\t\tdescription\t=\t\"{response.Value.Description}\"");
+                        sb.AppendLine($"\t\tdescription\t=\t\"{response.Value.Description?.Replace("\r\n", " ")}\"");
                         foreach (var representation in response.Value.Content)
                         {
                             sb.AppendLine("\t\trepresentation {");

--- a/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
+++ b/openapi-to-terraform.Generator/azurerm/v2_45_1/GeneratorModels/TerraformApimOperation.cs
@@ -30,7 +30,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                         sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary}\"");
                         sb.AppendLine($"\tmethod\t=\t\"{operation.Key.ToString().ToUpper()}\"");
                         sb.AppendLine($"\turl_template\t=\t\"{removeBackendServiceSegments(backendUrl, path.Key)}\"");
-                        sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description.Replace("\r\n", " ")}\"");
+                        sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description?.Replace("\r\n", " ")}\"");
                         foreach (var parameter in operation.Value.Parameters)
                         {
                             switch (parameter.In)
@@ -88,7 +88,7 @@ namespace openapi_to_terraform.Generator.azurerm.v2_45_1.GeneratorModels
                     sb.AppendLine($"\tdisplay_name\t=\t\"{operation.Value.Summary}\"");
                     sb.AppendLine($"\tmethod\t=\t\"{operation.Key.ToString().ToUpper()}\"");
                     sb.AppendLine($"\turl_template\t=\t\"{removeBackendServiceSegments(backendUrl, path.Key)}\"");
-                    sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description.Replace("\r\n", " ")}\"");
+                    sb.AppendLine($"\tdescription\t=\t\"{operation.Value.Description?.Replace("\r\n", " ")}\"");
                     foreach (var parameter in operation.Value.Parameters)
                     {
                         switch (parameter.In)

--- a/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
+++ b/openapi-to-terraform.Main/openapi-to-terraform.Main.csproj
@@ -9,7 +9,7 @@
     <PackageId>openapi-to-terraform</PackageId>
     <ToolCommandName>openapi-to-terraform</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageVersion>0.0.9</PackageVersion>
+    <PackageVersion>0.0.10</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openapi-to-terraform.Tests/samples/sampleOpenApi.json
+++ b/openapi-to-terraform.Tests/samples/sampleOpenApi.json
@@ -1,145 +1,196 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "Roomby Users API",
-      "description": "API for Roomby Users - Test",
-      "contact": {
-        "name": "Addison Waldow",
-        "email": "a.wal.bear@gmail.com"
-      },
-      "version": "1"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Roomby Users API",
+    "description": "API for Roomby Users - Test",
+    "contact": {
+      "name": "Addison Waldow",
+      "email": "a.wal.bear@gmail.com"
     },
-    "paths": {
-      "/api/v1/Households/{householdId}": {
-        "get": {
-          "tags": [
-            "Households"
-          ],
-          "summary": "GetHouseholdAsync(Guid householdId)",
-          "description": "Returns the Household object for householdId",
-          "operationId": "GetHouseholdAsync",
-          "parameters": [
-            {
-              "name": "householdId",
-              "in": "path",
+    "version": "1"
+  },
+  "paths": {
+    "/api/v1/Households/{householdId}": {
+      "get": {
+        "tags": [
+          "Households"
+        ],
+        "summary": "GetHouseholdAsync(Guid householdId)",
+        "description": "Returns the Household object for householdId",
+        "operationId": "GetHouseholdAsync",
+        "parameters": [
+          {
+            "name": "householdId",
+            "in": "path",
+            "description": "Household ID for the Household to get",
+            "required": true,
+            "schema": {
+              "type": "string",
               "description": "Household ID for the Household to get",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Household ID for the Household to get",
-                "format": "uuid"
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "401": {
-              "description": "Unauthorized",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "403": {
-              "description": "Forbidden",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Household"
                 }
               }
-            },
-            "500": {
-              "description": "Server Error"
-            },
-            "200": {
-              "description": "Success",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Household"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           }
         }
       },
-      "/api/v1/Users/{userId}": {
-        "get": {
-          "tags": [
-            "Users"
-          ],
-          "summary": "GetUserAsync(Guid userId)",
-          "description": "Returns the User object for userId",
-          "operationId": "GetUserAsync",
-          "parameters": [
-            {
-              "name": "userId",
-              "in": "path",
-              "description": "User ID for the User to get",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "User ID for the User to get",
-                "format": "uuid"
+      "delete": {
+        "tags": [
+          "Households"
+        ],
+        "operationId": "DeleteHouseholdAsync",
+        "parameters": [
+          {
+            "name": "householdId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "401": {
-              "description": "Unauthorized",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "403": {
-              "description": "Forbidden",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "500": {
-              "description": "Server Error"
-            },
-            "200": {
-              "description": "Success",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/User"
-                  }
+            }
+          },
+          "204": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Households": {
+      "post": {
+        "tags": [
+          "Households"
+        ],
+        "summary": "CreateHouseholdAsync(Household householdToCreate)",
+        "description": "Creates the provided householdToCreate",
+        "operationId": "CreateHouseholdAsync",
+        "requestBody": {
+          "description": "A Household object. See !:Roomby.API.Users.Mediators.CreateHouseholdValidator for validation information",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Household"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Household"
                 }
               }
             }
@@ -147,109 +198,243 @@
         }
       }
     },
-    "components": {
-      "schemas": {
-        "ProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
+    "/api/v1/Users/{userId}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "GetUserAsync(Guid userId)",
+        "description": "Returns the User object for userId",
+        "operationId": "GetUserAsync",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User ID for the User to get",
+            "required": true,
+            "schema": {
               "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
+              "description": "User ID for the User to get",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": { }
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Users": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "CreateUserAsync(User userToCreate)",
+        "description": "Creates the provided userToCreate",
+        "operationId": "CreateUserAsync",
+        "requestBody": {
+          "description": "A User object. See !:Roomby.API.Users.Mediators.CreateUserValidator for validation information",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
         },
-        "User": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "householdId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "createdAt": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedAt": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "fullName": {
-              "type": "string",
-              "nullable": true
-            },
-            "email": {
-              "type": "string",
-              "nullable": true
-            },
-            "identity": {
-              "type": "string",
-              "nullable": true
-            },
-            "provider": {
-              "type": "string",
-              "nullable": true
-            },
-            "subscriptionId": {
-              "type": "string",
-              "nullable": true
-            },
-            "household": {
-              "$ref": "#/components/schemas/Household"
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false
-        },
-        "Household": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "name": {
-              "type": "string",
-              "nullable": true
-            },
-            "headOfHouseholdId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "createdAt": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedAt": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "headOfHousehold": {
-              "$ref": "#/components/schemas/User"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false
+          "500": {
+            "description": "Server Error"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
         }
       }
     }
+  },
+  "components": {
+    "schemas": {
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {}
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "householdId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "identity": {
+            "type": "string",
+            "nullable": true
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscriptionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "household": {
+            "$ref": "#/components/schemas/Household"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Household": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "headOfHouseholdId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "headOfHousehold": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
   }
+}


### PR DESCRIPTION
There's an issue where (for some reason) Swashbuckle CLI will not pick up on some fields in an otherwise ok-looking XML comments block, and the description and summary for an operation may not appear. Since there's a replace to handle multiline strings in the operation description, null.Replace throws an error. This just uses the ?. syntax to handle the null case check inline.